### PR TITLE
🔀feat/result [아크네진단 결과화면 구현]

### DIFF
--- a/src/pages/diagnosis/Diagnosis.tsx
+++ b/src/pages/diagnosis/Diagnosis.tsx
@@ -17,15 +17,13 @@ const Diagnosis: React.FC = () => {
   const handleCancel = () => {
     setImage(null);
   };
-
-  const handleSubmit = () => {
-    if (image) {
-      alert('진단을 시작합니다.');
-    }
+  const handleDiagnose = () => {
+    if (!image) return;
+    const generatedId = 'log1'; // 여기서 AI 결과에 따라 동적으로 지정 가능
+    localStorage.setItem('uploadedImage', image);
+    goToPage(`/result/${generatedId}`);
   };
-
   const goToPage = useCustomNavigate();
-
   return (
     <S.UploadBox>
       <S.Title>
@@ -55,7 +53,7 @@ const Diagnosis: React.FC = () => {
       </S.GuideBox>
 
       <S.ButtonGroup>
-        <S.ActionButton primary disabled={!image} onClick={handleSubmit}>
+        <S.ActionButton primary disabled={!image} onClick={handleDiagnose}>
           진단하기
         </S.ActionButton>
         <S.ActionButton onClick={() => goToPage('/')}>취소하기</S.ActionButton>

--- a/src/pages/diagnosis/Result.styles.ts
+++ b/src/pages/diagnosis/Result.styles.ts
@@ -1,0 +1,137 @@
+import styled from 'styled-components';
+
+export const CloseButton = styled.button`
+  background: transparent;
+  border: none;
+  outline: none;
+  cursor: pointer;
+  font-size: 3rem;
+  position: absolute;
+  right: 38%;
+  top: 15%;
+`;
+
+export const Content = styled.div`
+  padding: 3rem;
+  width: 100%;
+`;
+
+export const Image = styled.img`
+  width: 50%;
+  height: 70%;
+  border-radius: 12px;
+  display: block;
+  margin: 0 auto 2rem;
+`;
+
+export const InfoSection = styled.section`
+  margin-bottom: 2rem;
+`;
+
+export const BlueBadge = styled.div`
+  background: #3182f6;
+  color: white;
+  padding: 0.3rem 1.2rem;
+  border-radius: 20px;
+  display: inline-block;
+  font-size: 1rem;
+  margin-right: 1rem;
+  margin-bottom: 0.1rem;
+`;
+export const BlackBadge = styled.div`
+  background: black;
+  color: white;
+  padding: 0.3rem 1.2rem;
+  border-radius: 20px;
+  display: inline-block;
+  font-size: 1rem;
+  margin-right: 1rem;
+  margin-bottom: 0.5rem;
+`;
+
+export const YellowBadge = styled.div`
+  background-color: rgba(255, 255, 0, 0.3);
+  color: black;
+  display: inline-block;
+  font-size: 15px;
+  font-weight: bold;
+  margin-bottom: 0.3rem;
+`;
+export const Title = styled.h2`
+  font-size: 1.5rem;
+  margin-bottom: 1rem;
+`;
+
+export const DetailList = styled.ul`
+  list-style: none;
+  padding-bottom: 2rem;
+  margin: 8px 0;
+  font-size: 1rem;
+`;
+
+export const Description = styled.div`
+  background: #f8f8f8;
+  padding: 1rem;
+  border-radius: 1rem;
+  font-size: 1rem;
+  color: gray;
+`;
+export const Section = styled.section`
+  margin-bottom: 2rem;
+
+  ul,
+  ol {
+    margin-bottom: 1rem;
+  }
+
+  li {
+    font-size: 1rem;
+    margin-bottom: 1rem;
+    margin-left: 1rem;
+  }
+`;
+
+export const RecommendSection = styled.section`
+  display: flex;
+  flex-direction: row;
+  cursor: pointer;
+  gap: 12px;
+  margin-bottom: 1rem;
+
+  .product-item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+  img {
+    width: 100%;
+    height: 80%;
+    border-radius: 14px;
+  }
+  p {
+    width: 100%;
+  }
+`;
+export const ButtonSection = styled.div`
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+`;
+export const BlueButton = styled.button`
+  background: #3b82f6;
+  color: white;
+  border-radius: 0.7rem;
+  padding: 1rem;
+  border: none;
+  width: 8rem;
+  height: 3rem;
+`;
+export const BlackButton = styled.button`
+  background: #0e0e0eff;
+  color: white;
+  border-radius: 0.7rem;
+  padding: 1rem;
+  border: none;
+  width: 8rem;
+  height: 3rem;
+`;

--- a/src/pages/diagnosis/Result.tsx
+++ b/src/pages/diagnosis/Result.tsx
@@ -1,0 +1,84 @@
+import { useParams } from 'react-router-dom';
+import useCustomNavigate from '../../hooks/useNavigate';
+import * as S from './Result.styles';
+import { resultMap } from './resultDummyData';
+
+const Result = () => {
+  const goToPage = useCustomNavigate();
+  const { id } = useParams(); // 주소창에서 /result/:id 를 가져옴
+  const result = resultMap[id!]; // id에 해당하는 결과 불러오기
+  const uploadedImage = localStorage.getItem('uploadedImage');
+
+  if (!result) return <p>결과를 찾을 수 없습니다.</p>;
+
+  return (
+    <S.Content>
+      <S.Title style={{ margin: '0 auto 2rem', width: 'fit-content' }}>진단 결과 확인하기</S.Title>
+      {uploadedImage && <S.Image src={uploadedImage} alt="사용자 업로드 이미지" />}
+      <hr style={{ border: 'none', borderTop: '1px solid #ccc', margin: '1rem 0' }} />
+
+      <S.InfoSection>
+        <S.Section>
+          <S.BlackBadge>진단결과</S.BlackBadge>
+          이미지 분석 결과,{'    '}
+          <S.YellowBadge style={{ color: 'red' }}>{result.diagnosisName}</S.YellowBadge>일 확률이
+          가장 높습니다.
+        </S.Section>
+        <S.Description>
+          <h3>☝️ '{result.diagnosisName}'이란?</h3>
+          <br />
+          {result.acneDescription}
+        </S.Description>
+      </S.InfoSection>
+
+      <S.Title>치료 및 관리 가이드</S.Title>
+      <S.Section>
+        <S.BlackBadge>치료법</S.BlackBadge>
+        <br />
+        {result.treatment.title}
+        <br />
+        {result.treatment.description}
+      </S.Section>
+
+      <S.Section>
+        <S.BlackBadge>관리 가이드</S.BlackBadge>
+        {result.managementTips.map((tip) => (
+          <ul key={tip.title}>
+            <S.YellowBadge>✔ {tip.title}</S.YellowBadge>
+            <li>{tip.description}</li>
+          </ul>
+        ))}
+      </S.Section>
+
+      <S.Title>이 영상 추천해요!</S.Title>
+      <S.RecommendSection>
+        {result.recommendedVideos.map((video, idx) => (
+          <div className="product-item" key={video.id}>
+            <img src={video.thumbnailUrl} alt={`추천 영상 ${idx + 1}`} />
+            <p>{video.title}</p>
+          </div>
+        ))}
+      </S.RecommendSection>
+
+      <S.Title>이 제품 추천해요!</S.Title>
+      <S.RecommendSection>
+        {result.recommendedProducts.map((product, idx) => (
+          <div className="product-item" key={product.id}>
+            <img src={product.imageUrl} alt={`추천 제품 ${idx + 1}`} />
+            <p>{product.name}</p>
+          </div>
+        ))}
+      </S.RecommendSection>
+      <S.ButtonSection>
+        <S.BlueButton onClick={() => goToPage('/')}>저장하기</S.BlueButton>
+        <S.BlackButton onClick={() => goToPage('/')}>홈으로 돌아가기</S.BlackButton>
+      </S.ButtonSection>
+      <br />
+      <br />
+      <br />
+      <br />
+    </S.Content>
+  );
+};
+
+export default Result;

--- a/src/pages/diagnosis/resultDummyData.ts
+++ b/src/pages/diagnosis/resultDummyData.ts
@@ -1,0 +1,93 @@
+export type Result = {
+  id: string;
+  imageUrl: string;
+  diagnosisName: string;
+  diagnosedAt: string;
+  userNickname: string;
+  acneDescription: string;
+  treatment: {
+    title: string;
+    description: string;
+  };
+  managementTips: {
+    title: string;
+    description: string;
+  }[];
+  recommendedProducts: {
+    id: string;
+    name: string;
+    imageUrl: string;
+  }[];
+  recommendedVideos: {
+    id: string;
+    title: string;
+    thumbnailUrl: string;
+  }[];
+};
+
+export const resultMap: Record<string, Result> = {
+  log1: {
+    id: 'log1',
+    imageUrl:
+      'https://cdn.automedi.co.kr/data/file/mir_module/3731727122_u2bI6DAV_EC97ACEB939CEBA684.jpg',
+    diagnosisName: '화농성 여드름',
+    diagnosedAt: '2025-07-02 10:00',
+    userNickname: '피부초보123',
+    acneDescription:
+      '화농성 여드름은 염증 반응이 심해 고름이 생기는 형태로, 자극 시 흉터가 남기 쉬우므로 전문적인 치료가 필요합니다.',
+    treatment: {
+      title: '항생제 및 염증 치료',
+      description: '화농 부위에는 국소 항생제와 염증 주사 치료를 병행하여 빠르게 진정시킵니다.',
+    },
+    managementTips: [
+      {
+        title: '손으로 짜지 마세요',
+        description: '손으로 여드름을 짜면 2차 감염 및 흉터가 생길 수 있습니다.',
+      },
+      {
+        title: '살리실산 제품 사용',
+        description: '피지 제거에 도움이 되는 살리실산 성분의 클렌저나 토너를 활용하세요.',
+      },
+      {
+        title: '세안 시 미온수 사용',
+        description: '뜨거운 물은 자극을 줄 수 있으니 미온수로 부드럽게 세안하세요.',
+      },
+      {
+        title: '베개 커버 자주 교체',
+        description: '피지와 땀이 쌓이기 쉬운 베개 커버는 자주 세탁하세요.',
+      },
+    ],
+    recommendedProducts: [
+      {
+        id: 'p1',
+        name: '라로슈포제 에빠끌라 클렌징폼',
+        imageUrl:
+          'https://thumbnail8.coupangcdn.com/thumbnails/remote/320x320ex/image/vendor_inventory/666d/7b8ec5ba3043d0a0f6f1e6d1312ed2a8b98c530aa09255006bf5afc1468c.jpg',
+      },
+      {
+        id: 'p2',
+        name: '센텔리안24 마데카 크림',
+        imageUrl:
+          'https://thumbnail8.coupangcdn.com/thumbnails/remote/320x320ex/image/vendor_inventory/666d/7b8ec5ba3043d0a0f6f1e6d1312ed2a8b98c530aa09255006bf5afc1468c.jpg',
+      },
+      {
+        id: 'p11',
+        name: '이니스프리 비자 시카 밤',
+        imageUrl:
+          'https://thumbnail8.coupangcdn.com/thumbnails/remote/320x320ex/image/vendor_inventory/666d/7b8ec5ba3043d0a0f6f1e6d1312ed2a8b98c530aa09255006bf5afc1468c.jpg',
+      },
+    ],
+    recommendedVideos: [
+      {
+        id: 'v1',
+        title: '화농성 여드름 관리법',
+        thumbnailUrl: 'https://img.youtube.com/vi/Ae83oJCP3dM/mqdefault.jpg',
+      },
+      {
+        id: 'v2',
+        title: '피부과전문의가 말하는 여드름 대처법',
+        thumbnailUrl: 'https://img.youtube.com/vi/Ae83oJCP3dM/mqdefault.jpg',
+      },
+    ],
+  },
+};

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -8,8 +8,9 @@ import My from '../pages/My/My';
 import SkinDiagnosis from '../pages/SkinDiagnosis';
 import Notice from '../pages/Notice';
 import PeoplesLog from '../pages/PeoplesLog/PeoplesLog';
-import Home from '../pages/home/Home';
-import Diagnosis from '../pages/diagnosis/Diagnosis';
+import Home from '../pages/Home/Home';
+import Diagnosis from '../pages/Diagnosis/Diagnosis';
+import Result from '../pages/Diagnosis/Result';
 
 function AppRouter() {
   return (
@@ -29,6 +30,7 @@ function AppRouter() {
             <Route path="/mylog" element={<MyLog />} />
             <Route path="/diagnosis" element={<Diagnosis />} />
             <Route path="/skin" element={<SkinDiagnosis />} />
+            <Route path="/result/:id" element={<Result />} />
           </Route>
         </Route>
 


### PR DESCRIPTION
# PR 템플릿
### 체크리스트!
- [x] ✅ base가 dev가 맞나요?
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


### 작업 내역
<!-- 어떻게 문제를 해결하였는지 -->
와이어프레임을 따라 라우팅 및 스타일링 완료하였습니다.



### 피드백을 받고 싶은 부분 
<!-- 작업 후 기대 동작(스크린샷) -->




### PR 특이 사항
<!-- 어떤 부분에 리뷰어가 집중하면 좋을까요? -->
1. 진단 결과화면에서 헤더부분이 아크네 진단으로 표시되어있도록 수정하면 좋을까요?
2. 사용자가 선택한 여드름 사진을 local storage에 저장되도록 처리해놓았습니다. 이후에 결과화면에서 저장하기 버튼을 누르면 DB에 저장되도록 수정하는 방식이라고 생각하고 그렇게 구현해놓았습니다. 이 부분이 맞을까요?


### 특이 사항 :
아크네 진단 화면에서 진단하기 버튼을 누르면 로딩화면이 연결되어야하지만 현재는 진단결과화면으로 바로 라우팅되어있습니다.


Issue Number:  자신이 개발 전에 올린 이슈번호: #18 

#### close:  자신이 개발 전에 올린 이슈번호
