### PR TITLE
dev to main [home화면 이미지 깨짐 해결]

### DIFF
--- a/src/pages/Homepage/Home.styles.tsx
+++ b/src/pages/Homepage/Home.styles.tsx
@@ -10,7 +10,7 @@ export const HomeSection = styled.div`
 export const Header = styled.div`
   display: flex;
   justify-content: space-between;
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.65rem;
 `;
 
 //리스트 공통
@@ -35,7 +35,8 @@ export const Itm = styled.div`
   text-align: center;
   cursor: pointer;
   img {
-    border-radius: 0.35rem;
+    padding: 0.2rem;
+    border-radius: 1rem;
   }
 `;
 

--- a/src/pages/Homepage/Home.tsx
+++ b/src/pages/Homepage/Home.tsx
@@ -24,7 +24,7 @@ function Home() {
         <S.List>
           {acneImages.map((item) => (
             <S.Itm key={item.id}>
-              <img src={item.src} width="100%" />
+              <img src={item.src} width="100%" height="120rem" />
               <div
                 style={{
                   display: 'flex',
@@ -47,7 +47,7 @@ function Home() {
         <S.List>
           {youtubeThumbnails.map((item) => (
             <S.Itm key={item.id}>
-              <img src={item.src} width="100%" />
+              <img src={item.src} width="100%" height="120rem" />
               <span>{item.title}</span>
             </S.Itm>
           ))}
@@ -60,7 +60,7 @@ function Home() {
         <S.List>
           {productRecommendations.map((item) => (
             <S.TodaysItemItm key={item.id}>
-              <img src={item.src} width="100%" />
+              <img src={item.src} width="100%" height="140rem" />
               <span>{item.title}</span>
             </S.TodaysItemItm>
           ))}

--- a/src/pages/Homepage/homeDummyData.ts
+++ b/src/pages/Homepage/homeDummyData.ts
@@ -2,19 +2,19 @@ export const acneImages = [
   {
     id: 1,
     title: '염증성 여드름',
-    src: 'src/assets/img/acne1.svg',
+    src: 'https://cdn.automedi.co.kr/data/file/mir_module/3731727122_u2bI6DAV_EC97ACEB939CEBA684.jpg',
     description: '염증성 여드름',
   },
   {
     id: 2,
     title: '좁쌀 여드름름',
-    src: 'src/assets/img/acne2.svg',
+    src: 'https://images.squarespace-cdn.com/content/v1/66271db24df4cd422370803d/a1218907-e4f5-41a5-8d7f-c006cba428f7/acne2.png',
     description: '좁쌀 여드름',
   },
   {
     id: 3,
     title: '화농성 여드름',
-    src: 'src/assets/img/acne3.svg',
+    src: 'https://d2u3dcdbebyaiu.cloudfront.net/uploads/atch_img/452/a70e98f85203fd1408b6c174869e7b93_res.jpeg',
     description: '화농성 여드름',
   },
 ];
@@ -23,19 +23,20 @@ export const youtubeThumbnails = [
   {
     id: 1,
     title: '피부과 전문의 추천 루틴',
-    src: 'src/assets/img/youtube1.svg',
+    src: 'https://img.youtube.com/vi/Ae83oJCP3dM/mqdefault.jpg',
     url: 'https://youtube.com/watch?v=xxxxx1',
   },
   {
     id: 2,
     title: '여드름 압출, 이렇게 하세요!',
-    src: 'src/assets/img/youtube2.svg',
+
+    src: 'https://img.youtube.com/vi/N5nLZGAzDn4/mqdefault.jpg',
     url: 'https://youtube.com/watch?v=xxxxx2',
   },
   {
     id: 3,
     title: '올바른 세안 방법',
-    src: 'src/assets/img/youtube3.svg',
+    src: 'https://img.youtube.com/vi/HMI1z9l2gC4/mqdefault.jpg',
     url: 'https://youtube.com/watch?v=xxxxx3',
   },
 ];
@@ -44,19 +45,19 @@ export const productRecommendations = [
   {
     id: 1,
     title: '여드름 압출 도구',
-    src: 'src/assets/img/coupang1.svg',
+    src: 'https://thumbnail1.coupangcdn.com/thumbnails/remote/292x292q65ex/image/retail/images/2022/12/16/18/5/865d6e25-116b-4258-b028-dd7671d851fd.jpg',
     url: 'https://link.coupang.com/product1',
   },
   {
     id: 2,
     title: '스팟 패치 베스트 셀러',
-    src: 'src/assets/img/coupang2.svg',
+    src: 'https://thumbnail6.coupangcdn.com/thumbnails/remote/320x320ex/image/retail/images/2024/08/26/16/3/3585deee-3b1d-4fef-83f0-a99683383bac.png',
     url: 'https://link.coupang.com/product2',
   },
   {
     id: 3,
     title: '여드름 전용 클렌저',
-    src: 'src/assets/img/coupang3.svg',
+    src: 'https://thumbnail9.coupangcdn.com/thumbnails/remote/320x320ex/image/retail/images/436373378704216-e22b0220-3a52-4b02-87f3-063431bdfc27.jpg',
     url: 'https://link.coupang.com/product3',
   },
 ];

--- a/src/pages/PeoplesLog/peoplesLogDetailDummyData.ts
+++ b/src/pages/PeoplesLog/peoplesLogDetailDummyData.ts
@@ -340,7 +340,7 @@ export const diagnosisDetailMap: Record<string, DiagnosisDetail> = {
         id: 'p15',
         name: '라로슈포제 시카플라스트 밤 B5',
         imageUrl:
-          'https://thumbnail8.coupangcdn.com/thumbnails/remote/320x320ex/image/vendor_inventory/666d/7b8ec5ba3043d0a0f6f1e6d1312ed2a8b98c530aa09255006bf5afc1468c.jpg',
+          'https://thumbnail9.coupangcdn.com/thumbnails/remote/320x320ex/image/retail/images/436373378704216-e22b0220-3a52-4b02-87f3-063431bdfc27.jpg',
       },
     ],
 
@@ -348,7 +348,7 @@ export const diagnosisDetailMap: Record<string, DiagnosisDetail> = {
       {
         id: 'v9',
         title: '여드름 피부의 생활 루틴',
-        thumbnailUrl: 'https://img.youtube.com/vi/rz7oQ0UBoQc/mqdefault.jpg',
+        thumbnailUrl: 'https://img.youtube.com/vi/HMI1z9l2gC4/mqdefault.jpg',
       },
       {
         id: 'v10',


### PR DESCRIPTION
### 작업 내역
<!-- 어떻게 문제를 해결하였는지 -->
이미지가 깨지는 이유는 dummy data에서 src/assets/...이런 방식으로 불러와서 라고 합니다.

그런데 한슬님이 알려주신 대로 import해서 쓰려니까 map방식을 쓰는데 어려움이 있었습니다.
그래서 한슬님이 peoplesLog페이지에서 이미지를 불러온 것처럼 dummy data에  src/assets/...이런 방식이 아니라 url링크를 저장하고 그걸 불러오는 방식으로 수정하였습니다. 피플즈로그, 나의 진단로그, 상세페이지 등에서 이 방식으로 이미지를 오류 없이 잘 불러오고 있어서 home페이지도 이 방식으로 이미지를 불러오도록 수정하였습니다..!

불러오는 방식이 달라지니까 margin부분에 오류가 생겨 css도 수정하였습니다.