### PR TITLE
feat/recommend-api [홈 페이지 오늘의 유튜브, 오늘의 추천템 API 연동 및 스타일 수정]

### DIFF
--- a/src/pages/Homepage/Home.styles.tsx
+++ b/src/pages/Homepage/Home.styles.tsx
@@ -36,17 +36,35 @@ export const Itm = styled.div`
   text-align: center;
   cursor: pointer;
   img {
-    margin-bottom: 0.3rem;
-    border-radius: 1.7rem;
+    width: 100%;
+    height: 8.75rem;
+    object-fit: cover;
+    border-radius: 1rem;
+  }
+  p {
+    font-size: 0.875rem; // 14px 정도
+    line-height: 1.2;
+    text-align: center;
+
+    /* 글자 길이 일정하게 표시 */
+    display: -webkit-box;
+    -webkit-line-clamp: 2; // 2줄까지만 표시
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 `;
-
+export const SharpIcon = styled.span`
+  img {
+    width: 1.7rem;
+    height: 1.7rem;
+  }
+`;
 //피플즈로그 게시물 개수
 export const PostCountText = styled.p`
   font-size: 0.75rem;
   color: #737373;
-  margin-right: 1.5rem;
-  margin-top: -0.2rem;
+  margin-right: 1.4rem;
   font-weight: normal;
 `;
 
@@ -55,7 +73,23 @@ export const TodaysItemItm = styled.div`
   width: 100%;
   cursor: pointer;
   img {
-    border-radius: 1.7rem;
+    width: 100%;
+    height: 8.75rem; // 이미지 영역
+    object-fit: cover; // 영역에 맞게 자르기
+    border-radius: 1rem;
+  }
+  p {
+    margin-top: 0.5rem;
+    font-size: 0.875rem; // 14px 정도
+    line-height: 1.2;
+    text-align: center;
+
+    /* 글자 길이 일정하게 표시 */
+    display: -webkit-box;
+    -webkit-line-clamp: 2; // 2줄까지만 표시
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
   margin-bottom: 6.25rem;
   text-align: center;

--- a/src/pages/Homepage/Home.tsx
+++ b/src/pages/Homepage/Home.tsx
@@ -1,10 +1,15 @@
 import useCustomNavigate from '../../hooks/useNavigate';
 import * as S from './Home.styles';
-import { youtubeThumbnails, productRecommendations } from './homeDummyData';
 import Banner from '../../assets/banner.svg';
 import sharp from '../../assets/img/sharpIcon.svg';
 import { useEffect, useState } from 'react';
-import { AcnePostCountData, homePeoplesLogService } from '../../services/homeService';
+import {
+  AcnePostCountData,
+  homePeoplesLogService,
+  RecommendProductItem,
+  recommendService,
+  RecommendViedoItem,
+} from '../../services/homeService';
 import { acneTypeData } from './homeAcneData';
 
 function Home() {
@@ -16,11 +21,17 @@ function Home() {
     PAPULES: 0,
     FOLLICULITIS: 0,
   });
+  const [youtube, setYoutube] = useState<RecommendViedoItem[]>([]);
+  const [product, setProduct] = useState<RecommendProductItem[]>([]);
 
   useEffect(() => {
     (async () => {
       const res = await homePeoplesLogService.getPeoplesLog();
+      const youtube = await recommendService.getRecommendVideo();
+      const product = await recommendService.getRecommendProduct();
       setPostCounts(res);
+      setYoutube(youtube);
+      setProduct(product);
     })();
   }, []);
 
@@ -53,7 +64,9 @@ function Home() {
                   gap: '0.5rem',
                 }}
               >
-                <img src={sharp} width="20%" />
+                <S.SharpIcon>
+                  <img src={sharp} />
+                </S.SharpIcon>
                 <span>{item.acneTypeKR}</span>
               </div>
               <S.PostCountText>
@@ -69,10 +82,10 @@ function Home() {
           <h2>오늘의 유튜브</h2>
         </S.Header>
         <S.List>
-          {youtubeThumbnails.slice(0, 3).map((item) => (
-            <S.Itm key={item.id}>
-              <img src={item.src} width="100%" height="140rem" />
-              <span>{item.title}</span>
+          {youtube.slice(0, 3).map((item) => (
+            <S.Itm key={item.videoId} onClick={() => window.open(item.videoUrl, '_blank')}>
+              <img src={item.thumbnailUrl} width="100%" height="140rem" />
+              <p>{item.videoTitle}</p>
             </S.Itm>
           ))}
         </S.List>
@@ -82,10 +95,13 @@ function Home() {
           <h2>오늘의 추천템</h2>
         </S.Header>
         <S.List>
-          {productRecommendations.map((item) => (
-            <S.TodaysItemItm key={item.id}>
-              <img src={item.src} width="100%" height="140rem" />
-              <span>{item.title}</span>
+          {product.map((item) => (
+            <S.TodaysItemItm
+              key={item.productId}
+              onClick={() => window.open(item.productUrl, '_blank')}
+            >
+              <img src={item.productImage} width="100%" height="140rem" />
+              <p>{item.productName}</p>
             </S.TodaysItemItm>
           ))}
         </S.List>

--- a/src/services/homeService.ts
+++ b/src/services/homeService.ts
@@ -4,10 +4,34 @@ export type AcnePostCountData = Record<
   'COMEDONES' | 'PUSTULES' | 'PAPULES' | 'FOLLICULITIS',
   number
 >;
-
+export interface RecommendViedoItem {
+  videoId: number;
+  videoUrl: string;
+  videoTitle: string;
+  thumbnailUrl: string;
+}
+export interface RecommendProductItem {
+  productId: number;
+  productUrl: string;
+  productName: string;
+  productImage: string;
+}
 export const homePeoplesLogService = {
   async getPeoplesLog(): Promise<AcnePostCountData> {
     const res = await apiPublic.get('/analysis/main');
+    // console.log(res.data.data);
+    return res.data.data;
+  },
+};
+
+export const recommendService = {
+  async getRecommendVideo(): Promise<RecommendViedoItem[]> {
+    const res = await apiPublic.get('/analysis/main/youtube');
+    // console.log(res.data.data);
+    return res.data.data;
+  },
+  async getRecommendProduct(): Promise<RecommendProductItem[]> {
+    const res = await apiPublic.get('analysis/main/product');
     // console.log(res.data.data);
     return res.data.data;
   },

--- a/src/services/noticeService.ts
+++ b/src/services/noticeService.ts
@@ -26,7 +26,7 @@ export const noticeService = {
     const sort = 'createdAt,desc';
     const queryString = `?page=${page}&size=${size}&sort=${sort}`;
     const res = await apiPublic.get(`/board/list${queryString}`);
-    console.log('[Notice Response]', res.data.data.content);
+    // console.log('[Notice Response]', res.data.data.content);
     return res.data.data;
   },
 };


### PR DESCRIPTION
# PR 템플릿
### 체크리스트!
- [x] ✅ base가 dev가 맞나요?
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


### 작업 내역
<!-- 어떻게 문제를 해결하였는지 -->
- 홈 페이지의 오늘의 유튜브, 오늘의 추천템 API를 연동하여 이미지와 제목을 화면에 표시하였습니다.
- 홈의 이미지들을 object-fit: cover 스타일을 주어서 잘리는 부분을 가운데를 중심이 되도록 수정하였습니다. 영상 제목이나 상품 이름이 긴 경우 일부만 표시되도록 스타일을 주었습니다.
- 제목들이 긴 경우 2줄까지만 표시하도록 하였습니다.

### 피드백을 받고 싶은 부분 
<!-- 작업 후 기대 동작(스크린샷) -->
상품과 영상의 이미지와 제목이 잘 조회가 되는지, 클릭 시 페이지 이동이 잘 되는지 확인 부탁드립니다!



### PR 특이 사항
<!-- 어떤 부분에 리뷰어가 집중하면 좋을까요? -->
스타일(border-radius)을 조금 변경해보았는데 괜찮은지 피드백 부탁드립니다!

### 특이 사항 :
Issue Number:  #46 

#### close:  #46 
